### PR TITLE
Re-Intilaizing pooled objects.

### DIFF
--- a/PoolManager.cs
+++ b/PoolManager.cs
@@ -1,81 +1,112 @@
 ﻿using UnityEngine;
-using System.Collections;
+using System.Linq;
 using System.Collections.Generic;
 
-public class PoolManager : MonoBehaviour {
+public class PoolManager : MonoBehaviour
+{
+    Dictionary<int, Queue<ObjectInstance>> poolDictionary = new Dictionary<int, Queue<ObjectInstance>>();
 
-	Dictionary<int,Queue<ObjectInstance>> poolDictionary = new Dictionary<int, Queue<ObjectInstance>> ();
+    static PoolManager _instance;
 
-	static PoolManager _instance;
+    public static PoolManager instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = FindObjectOfType<PoolManager>();
+            }
+            return _instance;
+        }
+    }
 
-	public static PoolManager instance {
-		get {
-			if (_instance == null) {
-				_instance = FindObjectOfType<PoolManager> ();
-			}
-			return _instance;
+    public void CreatePool(GameObject prefab, int poolSize)
+    {
+        int poolKey = prefab.GetInstanceID();
+
+        if (!poolDictionary.ContainsKey(poolKey))
+        {
+            poolDictionary.Add(poolKey, new Queue<ObjectInstance>());
+
+            GameObject poolHolder = new GameObject(prefab.name + " pool");
+            poolHolder.transform.parent = transform;
+
+            for (int i = 0; i < poolSize; i++)
+            {
+                ObjectInstance newObject = new ObjectInstance(Instantiate(prefab) as GameObject);
+                poolDictionary[poolKey].Enqueue(newObject);
+                newObject.SetParent(poolHolder.transform);
+            }
+        }
+    }
+    
+    public void ReuseObject(GameObject prefab, Vector3 position, Quaternion rotation, object args)
+    {
+        int poolKey = prefab.GetInstanceID();
+
+        if (poolDictionary.ContainsKey(poolKey))
+        {
+            ObjectInstance objectToReuse = poolDictionary[poolKey].Dequeue();
+            poolDictionary[poolKey].Enqueue(objectToReuse);
+
+            objectToReuse.Reuse(position, rotation, args);
+        }
+    }
+
+    public List<ObjectInstance> GetActiveObjects(GameObject prefab)
+    {
+        int poolKey = prefab.GetInstanceID();
+        var active = new List<ObjectInstance>();
+
+        if (!poolDictionary.ContainsKey(poolKey))
+            return null;
+
+        var prefabInstances = poolDictionary[poolKey].ToList();
+        for (int i = 0; i < prefabInstances.Count; i++)
+        {
+            if (prefabInstances[i].GameObject.activeInHierarchy)
+                active.Add(prefabInstances[i]);
+        }
+        return active;
+    }
+}
+
+ [System.Serializable]
+public class ObjectInstance {
+
+	GameObject gameObject;
+	Transform transform;
+
+	bool hasPoolObjectComponent;
+	PoolObject poolObjectScript;
+
+    public GameObject GameObject
+    {
+        get { return gameObject; }
+    }
+
+	public ObjectInstance(GameObject objectInstance) {
+		gameObject = objectInstance;
+		transform = gameObject.transform;
+		gameObject.SetActive(false);
+
+		if (gameObject.GetComponent<PoolObject>()) {
+			hasPoolObjectComponent = true;
+			poolObjectScript = gameObject.GetComponent<PoolObject>();
 		}
 	}
 
-	public void CreatePool(GameObject prefab, int poolSize) {
-		int poolKey = prefab.GetInstanceID ();
+	public void Reuse(Vector3 position, Quaternion rotation, object args = null) {
+		gameObject.SetActive (true);
+		transform.position = position;
+		transform.rotation = rotation;
 
-		if (!poolDictionary.ContainsKey (poolKey)) {
-			poolDictionary.Add (poolKey, new Queue<ObjectInstance> ());
-
-			GameObject poolHolder = new GameObject (prefab.name + " pool");
-			poolHolder.transform.parent = transform;
-
-			for (int i = 0; i < poolSize; i++) {
-				ObjectInstance newObject = new ObjectInstance(Instantiate (prefab) as GameObject);
-				poolDictionary [poolKey].Enqueue (newObject);
-				newObject.SetParent (poolHolder.transform);
-			}
+		if (hasPoolObjectComponent) {
+			poolObjectScript.OnObjectReuse (args);
 		}
 	}
 
-	public void ReuseObject(GameObject prefab, Vector3 position, Quaternion rotation) {
-		int poolKey = prefab.GetInstanceID ();
-
-		if (poolDictionary.ContainsKey (poolKey)) {
-			ObjectInstance objectToReuse = poolDictionary [poolKey].Dequeue ();
-			poolDictionary [poolKey].Enqueue (objectToReuse);
-
-			objectToReuse.Reuse (position, rotation);
-		}
-	}
-
-	public class ObjectInstance {
-
-		GameObject gameObject;
-		Transform transform;
-
-		bool hasPoolObjectComponent;
-		PoolObject poolObjectScript;
-
-		public ObjectInstance(GameObject objectInstance) {
-			gameObject = objectInstance;
-			transform = gameObject.transform;
-			gameObject.SetActive(false);
-
-			if (gameObject.GetComponent<PoolObject>()) {
-				hasPoolObjectComponent = true;
-				poolObjectScript = gameObject.GetComponent<PoolObject>();
-			}
-		}
-
-		public void Reuse(Vector3 position, Quaternion rotation) {
-			gameObject.SetActive (true);
-			transform.position = position;
-			transform.rotation = rotation;
-
-			if (hasPoolObjectComponent) {
-				poolObjectScript.OnObjectReuse ();
-			}
-		}
-
-		public void SetParent(Transform parent) {
-			transform.parent = parent;
-		}
+	public void SetParent(Transform parent) {
+		transform.parent = parent;
 	}
 }

--- a/PoolObject.cs
+++ b/PoolObject.cs
@@ -1,13 +1,39 @@
 ﻿using UnityEngine;
-using System.Collections;
 
 public class PoolObject : MonoBehaviour {
+    [HideInInspector]
+    protected float timeToDie;
 
-	public virtual void OnObjectReuse() {
+    /// <summary>
+    /// Disable after a certain time has passed
+    /// </summary>
+    public void Disable()
+    {
+        SetInactive(timeToDie);
+    }
 
-	}
+    /// <summary>
+    /// Set inactive with delay
+    /// </summary>
+    /// <param name="time"></param>
+    void SetInactive(float time)
+    {
+        Invoke("SetInactive", time);
+    }
 
-	protected void Destroy() {
-		gameObject.SetActive (false);
-	}
+    /// <summary>
+    /// set inactive immediately
+    /// </summary>
+    protected void SetInactive()
+    {
+        gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Resue this object
+    /// </summary>
+    /// <param name="args"> pass a data </param>
+    public virtual void OnObjectReuse(object args) {
+        Disable();
+    }
 }


### PR DESCRIPTION
Pooled objects can now be reinitialized before reuse by passing a custom data-type to the "args" parameter.

```
[System.Serializable]
public class WaveData
{
    public float initialScale;
    public float timeToFade;
    public float maxExpandSize;
    public Color colorOfWave;
    public Special specialMove;
    public WaveData()
    { }
}

public class BadDot : MonoBehaviour {
    public GameObject wavePrefab;

    public WaveData args;
    public float sqawnInterval;

    void Start () {
        StartCoroutine(Use());
    }

    IEnumerator Use()
    {
        yield return new WaitForSeconds(sqawnInterval);
       PoolManager.instance.ReuseObject(wavePrefab, transform.position, args);
        StartCoroutine(Use());
    }
}

public class Wave : PoolObject {

    public override void OnObjectReuse(object args)
    {
        var _args  = (WaveData)args;
        timeToDie  = _args.timeToFade;

        GetComponent<PolygonCollider2D>().enabled = true;
        StartCoroutine(Disable(3 * _args.timeToFade / 4));
        
        transform.localScale = Vector3.one * _args.initialScale;
        gameObject.GetComponent<SpriteRenderer>().color = _args.colorOfWave;
        
        transform.DOScale(_args.maxExpandSize, _args.timeToFade);

        gameObject.GetComponent<SpriteRenderer>().DOColor(new Color(1,1,1,0), _args.timeToFade);
        
        base.OnObjectReuse(args);
    }
}
```